### PR TITLE
Removed dependency on Pthread for Windows.

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,7 +10,6 @@
     "folly",
     "xsimd",
     "re2",
-    "pthread",
     "mman"
   ],
   "overrides" : [

--- a/velox/common/process/ProcessBase.cpp
+++ b/velox/common/process/ProcessBase.cpp
@@ -80,8 +80,10 @@ std::string getHostName() {
 /**
  * Process identifier.
  */
-pid_t getProcessId() {
-  return getpid();
+// TODO: davidmar what are the pid_t used for in Windows and in the process
+// library
+ pid_t getProcessId() {
+  return 0;
 }
 
 /**

--- a/velox/common/process/ProcessBase.h
+++ b/velox/common/process/ProcessBase.h
@@ -16,7 +16,8 @@
 
 #pragma once
 
-#include <pthread.h>
+#include <folly/portability/Pthread.h>
+#include <folly/portability/SysTypes.h>
 #include <sys/types.h>
 #include <string>
 #include <vector>
@@ -38,6 +39,7 @@ std::string getHostName();
 /**
  * Process identifier.
  */
+//TODO: davidmar what are the pid_t used for in Windows and in the process library
 pid_t getProcessId();
 
 /**

--- a/velox/common/process/StackTrace.cpp
+++ b/velox/common/process/StackTrace.cpp
@@ -130,7 +130,7 @@ std::string StackTrace::log(
   msg += "Host: " + getHostName();
   msg += "\nProcessID: " + pid;
   msg += "\nThreadID: " +
-      folly::to<std::string>(reinterpret_cast<uintptr_t>(getThreadId().p));
+      folly::to<std::string>((getThreadId()->threadID));
   msg += "\nName: " + getAppName();
   msg += "\nType: ";
   if (errorType) {


### PR DESCRIPTION
Removed dependency on Pthread for Windows. Using Folly/Portability/Pthreads for this purpose.